### PR TITLE
Avoid needing to use html5ever on the write path.

### DIFF
--- a/weft/Cargo.toml
+++ b/weft/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/weft"
 edition = "2018"
 
 [dependencies]
+v_htmlescape = "0.4.5"
 
 [dependencies.weft_derive]
 path = "../derive"

--- a/weft/Cargo.toml
+++ b/weft/Cargo.toml
@@ -11,8 +11,6 @@ documentation = "https://docs.rs/weft"
 edition = "2018"
 
 [dependencies]
-html5ever = "0.25.0"
-markup5ever = "0.10.0"
 
 [dependencies.weft_derive]
 path = "../derive"

--- a/weft/src/template.rs
+++ b/weft/src/template.rs
@@ -57,7 +57,7 @@ impl<'a, T: 'a + io::Write> RenderTarget for Html5Ser<T> {
         write!(self.0, "<{}", name.0)?;
         for attr in attrs {
             // TODO: Escaping!
-            write!(self.0, " {}=\"{}\"", attr.name, attr.value)?;
+            write!(self.0, " {}=\"{}\"", attr.name, escape(&attr.value))?;
         }
         write!(self.0, ">")?;
         Ok(())

--- a/weft/src/template.rs
+++ b/weft/src/template.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use v_htmlescape::escape;
+
 /// An internal representation of a qualified name, such as a tag or attribute.
 /// Does not currently support namespaces.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -61,8 +63,7 @@ impl<'a, T: 'a + io::Write> RenderTarget for Html5Ser<T> {
         Ok(())
     }
     fn text(&mut self, content: &str) -> Result<(), io::Error> {
-        // TODO: Escaping!
-        write!(self.0, "{}", content)?;
+        write!(self.0, "{}", escape(content))?;
         Ok(())
     }
     fn end_element(&mut self, name: QName) -> Result<(), io::Error> {

--- a/weft/tests/canary.rs
+++ b/weft/tests/canary.rs
@@ -357,3 +357,22 @@ fn should_support_boxed_content() {
         expected
     )
 }
+
+#[test]
+fn should_correctly_escape_content_in_text() {
+    let view = WithContent {
+        child: "<script src=\"xss.js\"/>".into(),
+    };
+
+    let s = weft::render_to_string(view).expect("render_to_string");
+    println!("{}", s);
+
+    let unwanted = "<script";
+    assert!(
+        !s.contains(unwanted),
+        "String {:?} does not contain {:?}",
+        s,
+        unwanted
+    )
+
+}

--- a/weft/tests/canary.rs
+++ b/weft/tests/canary.rs
@@ -374,5 +374,22 @@ fn should_correctly_escape_content_in_text() {
         s,
         unwanted
     )
+}
 
+#[test]
+fn should_correctly_escape_content_in_attrs() {
+    #[derive(WeftRenderable)]
+    #[template(source = "<p class=\"{{self.0}}\"/>")]
+    struct Para(String);
+
+    let s = weft::render_to_string(Para("\"><script src=\"xss.js\"/>".into())).expect("render_to_string");
+    println!("{}", s);
+
+    let unwanted = "class=\"\"><script ";
+    assert!(
+        !s.contains(unwanted),
+        "String {:?} should not contain {:?}",
+        s,
+        unwanted
+    );
 }


### PR DESCRIPTION
Building an element or attribute name in html5ever attempts to use a string cache to save on memory. However, because we're not using it very well, this mostly incurs a mutex lock, a miss, and an allocation, and benchmarks show that when multiple templates are rendered concurrently, this locking overhead becomes quite significant.

So, switch to just serialising directly, albeit with some help from `v_htmlescape`.