### PR TITLE
Avoid type erasure where possible.

### DIFF
--- a/derive/src/derive_renderable.rs
+++ b/derive/src/derive_renderable.rs
@@ -38,7 +38,7 @@ fn render_to_fn(nodes: NodeRef) -> Result<TokenStream2, Error> {
     let walker = Walker::default();
     let impl_body = walker.children(nodes.children())?;
     Ok(quote! {
-            fn render_to(&self, __weft_target: &mut ::weft::RenderTarget) -> Result<(), ::std::io::Error> {
+            fn render_to(&self, mut __weft_target: impl ::weft::RenderTarget) -> Result<(), ::std::io::Error> {
                 use ::weft::prelude::*;
                 #impl_body;
                 Ok(())
@@ -137,9 +137,9 @@ impl Walker {
 
         let directive = Directives::parse_from_attrs(&data.attributes.borrow())?;
         let res = if let Some(repl) = directive.replacement {
-            quote!(#repl.render_to(__weft_target)?;)
+            quote!(#repl.render_to(&mut __weft_target)?;)
         } else if let Some(content) = directive.content {
-            let content = quote!(#content.render_to(__weft_target)?;);
+            let content = quote!(#content.render_to(&mut __weft_target)?;);
             self.emit_element(&localname, &*directive.plain_attrs, content)?
         } else {
             let content = self.children(children)?;
@@ -173,7 +173,7 @@ impl Walker {
                     result.extend(chunk);
                 }
                 Segment::Expr(expr) => {
-                    let chunk = quote!(#expr.render_to(__weft_target)?;);
+                    let chunk = quote!(#expr.render_to(&mut __weft_target)?;);
                     result.extend(chunk);
                 }
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -4,11 +4,11 @@ This module provides compiler support for creating `weft` templates. See the `we
 */
 
 extern crate proc_macro;
-use proc_macro2;
 use env_logger;
 use failure::bail;
 use kuchiki;
 use log::*;
+use proc_macro2;
 use syn::Token;
 
 mod derive_renderable;

--- a/weft/benches/templates.rs
+++ b/weft/benches/templates.rs
@@ -108,7 +108,10 @@ fn big_table_reuse_buffer(b: &mut test::Bencher, size: usize) {
     weft::render_writer(&tmpl, &mut buf).expect("render");
     b.bytes = buf.len().try_into().unwrap();
 
-    let thunk = || { buf.clear(); weft::render_writer(&tmpl, &mut buf)};
+    let thunk = || {
+        buf.clear();
+        weft::render_writer(&tmpl, &mut buf)
+    };
 
     b.iter(thunk);
 }

--- a/weft/src/extensions.rs
+++ b/weft/src/extensions.rs
@@ -17,19 +17,19 @@ impl<D: fmt::Display> Displayable for D {
 }
 
 impl<'a> WeftRenderable for &'a str {
-    fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
         target.text(self)
     }
 }
 
 impl WeftRenderable for String {
-    fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
         target.text(self)
     }
 }
 
 impl<'a, D: fmt::Display> WeftRenderable for Displayer<'a, D> {
-    fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
         target.text(&self.to_string())
     }
 }

--- a/weft/src/template.rs
+++ b/weft/src/template.rs
@@ -100,12 +100,17 @@ struct Html5Ser<T>(T);
 
 impl<'a, T: 'a + io::Write> RenderTarget for Html5Ser<T> {
     fn start_element_attrs(&mut self, name: QName, attrs: &[&AttrPair]) -> Result<(), io::Error> {
-        write!(self.0, "<{}", name.0)?;
+        self.0.write_all(b"<")?;
+        self.0.write_all(name.0.as_bytes())?;
+
         for attr in attrs {
             // TODO: Escaping!
-            write!(self.0, " {}=\"{}\"", attr.name, escape(&attr.value))?;
+            self.0.write_all(b" ")?;
+            self.0.write_all(attr.name.as_bytes())?;
+            self.0.write_all(b"=")?;
+            write!(self.0, "\"{}\"", escape(&attr.value))?;
         }
-        write!(self.0, ">")?;
+        self.0.write_all(b">")?;
         Ok(())
     }
     fn text(&mut self, content: &str) -> Result<(), io::Error> {
@@ -113,7 +118,9 @@ impl<'a, T: 'a + io::Write> RenderTarget for Html5Ser<T> {
         Ok(())
     }
     fn end_element(&mut self, name: QName) -> Result<(), io::Error> {
-        write!(self.0, "</{}>", name.0)?;
+        self.0.write_all(b"</")?;
+        self.0.write_all(name.0.as_bytes())?;
+        self.0.write_all(b">")?;
         Ok(())
     }
 }

--- a/weft/src/template.rs
+++ b/weft/src/template.rs
@@ -44,9 +44,31 @@ pub trait WeftRenderable {
     fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error>;
 }
 
+/// This is exactly like the `WeftRenderable` trait, but for cases where
+/// we need a trait object. Eg: for a `Vec<Box<dyn ErasedRenderable>>`.
+pub trait ErasedRenderable {
+    /// Outputs a representation of this object to the target.
+    fn erased_render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error>;
+}
+
 impl<'a, R: WeftRenderable> WeftRenderable for &'a R {
     fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
         (**self).render_to(target)
+    }
+}
+
+impl<T> ErasedRenderable for T
+where
+    T: WeftRenderable,
+{
+    fn erased_render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        self.render_to(target)
+    }
+}
+
+impl WeftRenderable for dyn ErasedRenderable {
+    fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        self.erased_render_to(target)
     }
 }
 

--- a/weft/tests/api_for_renderable.rs
+++ b/weft/tests/api_for_renderable.rs
@@ -10,7 +10,7 @@ fn should_render_trivial_example() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
             target.start_element_attrs("p".into(), &[])?;
             target.text("Hello".into())?;
             target.end_element("p".into())?;
@@ -33,7 +33,7 @@ fn should_render_attrs() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
             target.start_element_attrs("p".into(), &[&AttrPair::new("class", "some-classes")])?;
             target.text("Hello".into())?;
             target.end_element("p".into())?;
@@ -57,7 +57,7 @@ fn render_supports_builtins() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: impl RenderTarget) -> Result<(), io::Error> {
             "Hello world!".render_to(target)?;
             Ok(())
         }
@@ -78,7 +78,7 @@ fn display_supports_renderable() {
     struct Displayable<D>(D);
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl<D: fmt::Display> WeftRenderable for Displayable<D> {
-        fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: impl RenderTarget) -> Result<(), io::Error> {
             use weft::prelude::*;
             self.0.display().render_to(target)?;
             Ok(())
@@ -95,7 +95,7 @@ fn display_supports_to_string() {
     struct Displayable<D>(D);
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl<D: fmt::Display> WeftRenderable for Displayable<D> {
-        fn render_to(&self, target: &mut dyn RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
             use weft::prelude::*;
             target.start_element_attrs(
                 "p".into(),

--- a/weft/tests/canary.rs
+++ b/weft/tests/canary.rs
@@ -337,7 +337,7 @@ fn should_import_displayable() {
 #[derive(WeftRenderable)]
 #[template(path = "tests/content.html")]
 struct WithBoxedContent {
-    child: Box<dyn weft::WeftRenderable>,
+    child: Box<dyn weft::ErasedRenderable>,
 }
 
 #[test]

--- a/weft/tests/canary.rs
+++ b/weft/tests/canary.rs
@@ -1,5 +1,5 @@
 use weft;
-use weft_derive::{WeftRenderable};
+use weft_derive::WeftRenderable;
 
 use regex::*;
 
@@ -382,7 +382,8 @@ fn should_correctly_escape_content_in_attrs() {
     #[template(source = "<p class=\"{{self.0}}\"/>")]
     struct Para(String);
 
-    let s = weft::render_to_string(Para("\"><script src=\"xss.js\"/>".into())).expect("render_to_string");
+    let s = weft::render_to_string(Para("\"><script src=\"xss.js\"/>".into()))
+        .expect("render_to_string");
     println!("{}", s);
 
     let unwanted = "class=\"\"><script ";


### PR DESCRIPTION
This should mean tht the compiler can do more monomorphisation, and hopefully better optimisations. This seems to result in a ~11%-24% speedup.

Before:

```
running 11 tests
test big_table_allocating_001x001   ... bench:       3,088 ns/iter (+/- 328) = 28 MB/s
test big_table_allocating_004x004   ... bench:      11,294 ns/iter (+/- 1,307) = 25 MB/s
test big_table_allocating_016x016   ... bench:     127,528 ns/iter (+/- 10,280) = 23 MB/s
test big_table_allocating_064x064   ... bench:   1,988,660 ns/iter (+/- 180,416) = 22 MB/s
test big_table_allocating_256x256   ... bench:  32,085,038 ns/iter (+/- 2,527,404) = 23 MB/s
test big_table_reuse_buffer_001x001 ... bench:       2,204 ns/iter (+/- 1,187) = 39 MB/s
test big_table_reuse_buffer_004x004 ... bench:       9,978 ns/iter (+/- 1,485) = 28 MB/s
test big_table_reuse_buffer_016x016 ... bench:     124,578 ns/iter (+/- 16,225) = 23 MB/s
test big_table_reuse_buffer_064x064 ... bench:   2,105,703 ns/iter (+/- 791,580) = 21 MB/s
test big_table_reuse_buffer_256x256 ... bench:  31,405,820 ns/iter (+/- 5,002,150) = 24 MB/s
test teams                          ... bench:       9,183 ns/iter (+/- 912) = 35 MB/s
```

After:
```
running 11 tests
test big_table_allocating_001x001   ... bench:       2,690 ns/iter (+/- 341) = 32 MB/s
test big_table_allocating_004x004   ... bench:       9,697 ns/iter (+/- 828) = 29 MB/s
test big_table_allocating_016x016   ... bench:     107,350 ns/iter (+/- 8,601) = 27 MB/s
test big_table_allocating_064x064   ... bench:   1,669,994 ns/iter (+/- 224,270) = 27 MB/s
test big_table_allocating_256x256   ... bench:  28,423,436 ns/iter (+/- 3,398,518) = 26 MB/s
test big_table_reuse_buffer_001x001 ... bench:       1,772 ns/iter (+/- 325) = 49 MB/s
test big_table_reuse_buffer_004x004 ... bench:       8,521 ns/iter (+/- 538) = 33 MB/s
test big_table_reuse_buffer_016x016 ... bench:     107,351 ns/iter (+/- 11,930) = 27 MB/s
test big_table_reuse_buffer_064x064 ... bench:   1,662,150 ns/iter (+/- 315,108) = 27 MB/s
test big_table_reuse_buffer_256x256 ... bench:  28,168,557 ns/iter (+/- 8,473,894) = 27 MB/s
test teams                          ... bench:       7,962 ns/iter (+/- 680) = 41 MB/s
```