### PR TITLE
Attempt to avoid extra indirections.

### DIFF
--- a/derive/src/derive_renderable.rs
+++ b/derive/src/derive_renderable.rs
@@ -38,7 +38,7 @@ fn render_to_fn(nodes: NodeRef) -> Result<TokenStream2, Error> {
     let walker = Walker::default();
     let impl_body = walker.children(nodes.children())?;
     Ok(quote! {
-            fn render_to(&self, mut __weft_target: impl ::weft::RenderTarget) -> Result<(), ::std::io::Error> {
+            fn render_to(&self, mut __weft_target: &mut impl ::weft::RenderTarget) -> Result<(), ::std::io::Error> {
                 use ::weft::prelude::*;
                 #impl_body;
                 Ok(())

--- a/weft/src/extensions.rs
+++ b/weft/src/extensions.rs
@@ -17,19 +17,19 @@ impl<D: fmt::Display> Displayable for D {
 }
 
 impl<'a> WeftRenderable for &'a str {
-    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
         target.text(self)
     }
 }
 
 impl WeftRenderable for String {
-    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
         target.text(self)
     }
 }
 
 impl<'a, D: fmt::Display> WeftRenderable for Displayer<'a, D> {
-    fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+    fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
         target.text(&self.to_string())
     }
 }

--- a/weft/tests/api_for_renderable.rs
+++ b/weft/tests/api_for_renderable.rs
@@ -10,7 +10,7 @@ fn should_render_trivial_example() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
             target.start_element_attrs("p".into(), &[])?;
             target.text("Hello".into())?;
             target.end_element("p".into())?;
@@ -33,7 +33,7 @@ fn should_render_attrs() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
             target.start_element_attrs("p".into(), &[&AttrPair::new("class", "some-classes")])?;
             target.text("Hello".into())?;
             target.end_element("p".into())?;
@@ -57,7 +57,7 @@ fn render_supports_builtins() {
     struct TrivialExample;
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl WeftRenderable for TrivialExample {
-        fn render_to(&self, target: impl RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
             "Hello world!".render_to(target)?;
             Ok(())
         }
@@ -78,7 +78,7 @@ fn display_supports_renderable() {
     struct Displayable<D>(D);
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl<D: fmt::Display> WeftRenderable for Displayable<D> {
-        fn render_to(&self, target: impl RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
             use weft::prelude::*;
             self.0.display().render_to(target)?;
             Ok(())
@@ -95,7 +95,7 @@ fn display_supports_to_string() {
     struct Displayable<D>(D);
     // This simulates what a template of the form `<p>Hello</p>` should compile to.
     impl<D: fmt::Display> WeftRenderable for Displayable<D> {
-        fn render_to(&self, mut target: impl RenderTarget) -> Result<(), io::Error> {
+        fn render_to(&self, target: &mut impl RenderTarget) -> Result<(), io::Error> {
             use weft::prelude::*;
             target.start_element_attrs(
                 "p".into(),


### PR DESCRIPTION
https://github.com/cstorey/weft/pull/46 resulted in a situation where calling a child component would add another layer of `&mut` to the render target value. Avoiding this means fewer pointer indirections.